### PR TITLE
Proxy new Ghost hosted blog

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -10,7 +10,7 @@ https://www.inbeat.co/articles/ugc-marketing-an-ultimate-guide-to-leverage-user-
 https://www.inbeat.co/articles/ultimate-guide-to-tiktok-influencer-marketing/ https://www.inbeat.co/articles/tiktok-influencer-marketing/ 301!
 https://www.inbeat.co/articles/brand-ambassador-programs-a-complete-guide-2021 https://www.inbeat.co/articles/brand-ambassador-programs 301!
 https://www.inbeat.co/articles/creating-a-brand-ambassador-program https://www.inbeat.co/articles/brand-ambassador-programs 301!
-/blog/* https://inbeat-blog.ghost.io/:splat 200
+/blog/* https://inbeat-blog.ghost.io/blog/:splat 200
 /content/* https://inbeat-blog.ghost.io/content/:splat 200
 /assets/* https://inbeat-blog.ghost.io/assets/:splat 200
 /public/* https://inbeat-blog.ghost.io/public/:splat 200

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,4 +1,4 @@
-https://mg.inbeat.co/_ https://www.inbeat.co/:splat 301!
+https://mg.inbeat.co/* https://www.inbeat.co/:splat 301!
 https://www.inbeat.co/categories/tips https://www.inbeat.co/categories/influencer-marketing 301!
 https://www.inbeat.co/categories/studies https://www.inbeat.co/categories/micro-influencer-marketing 301!
 https://www.inbeat.co/categories/tutorials https://www.inbeat.co/categories/ugc 301!

--- a/static/_redirects
+++ b/static/_redirects
@@ -11,6 +11,9 @@ https://www.inbeat.co/articles/ultimate-guide-to-tiktok-influencer-marketing/ ht
 https://www.inbeat.co/articles/brand-ambassador-programs-a-complete-guide-2021 https://www.inbeat.co/articles/brand-ambassador-programs 301!
 https://www.inbeat.co/articles/creating-a-brand-ambassador-program https://www.inbeat.co/articles/brand-ambassador-programs 301!
 /blog/* https://inbeat-blog.ghost.io/:splat 200
+/content/* https://inbeat-blog.ghost.io/content/:splat 200
+/assets/* https://inbeat-blog.ghost.io/assets/:splat 200
+/public/* https://inbeat-blog.ghost.io/public/:splat 200
 
 # Redirect default Netlify subdomain to primary domain
 

--- a/static/_redirects
+++ b/static/_redirects
@@ -10,10 +10,10 @@ https://www.inbeat.co/articles/ugc-marketing-an-ultimate-guide-to-leverage-user-
 https://www.inbeat.co/articles/ultimate-guide-to-tiktok-influencer-marketing/ https://www.inbeat.co/articles/tiktok-influencer-marketing/ 301!
 https://www.inbeat.co/articles/brand-ambassador-programs-a-complete-guide-2021 https://www.inbeat.co/articles/brand-ambassador-programs 301!
 https://www.inbeat.co/articles/creating-a-brand-ambassador-program https://www.inbeat.co/articles/brand-ambassador-programs 301!
-/blog/* https://inbeat-blog.ghost.io/blog/:splat 200
-/content/* https://inbeat-blog.ghost.io/content/:splat 200
-/assets/* https://inbeat-blog.ghost.io/assets/:splat 200
-/public/* https://inbeat-blog.ghost.io/public/:splat 200
+/blog/* https://blog.inbeat.co/blog/:splat 200
+/content/* https://blog.inbeat.co/content/:splat 200
+/assets/* https://blog.inbeat.co/assets/:splat 200
+/public/* https://blog.inbeat.co/public/:splat 200
 
 # Redirect default Netlify subdomain to primary domain
 

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,4 +1,4 @@
-https://mg.inbeat.co/* https://www.inbeat.co/:splat 301!
+https://mg.inbeat.co/_ https://www.inbeat.co/:splat 301!
 https://www.inbeat.co/categories/tips https://www.inbeat.co/categories/influencer-marketing 301!
 https://www.inbeat.co/categories/studies https://www.inbeat.co/categories/micro-influencer-marketing 301!
 https://www.inbeat.co/categories/tutorials https://www.inbeat.co/categories/ugc 301!
@@ -10,11 +10,8 @@ https://www.inbeat.co/articles/ugc-marketing-an-ultimate-guide-to-leverage-user-
 https://www.inbeat.co/articles/ultimate-guide-to-tiktok-influencer-marketing/ https://www.inbeat.co/articles/tiktok-influencer-marketing/ 301!
 https://www.inbeat.co/articles/brand-ambassador-programs-a-complete-guide-2021 https://www.inbeat.co/articles/brand-ambassador-programs 301!
 https://www.inbeat.co/articles/creating-a-brand-ambassador-program https://www.inbeat.co/articles/brand-ambassador-programs 301!
+/blog/* https://inbeat-blog.ghost.io/:splat 200
 
 # Redirect default Netlify subdomain to primary domain
+
 https://mystifying-allen-be5d31.netlify.com/* https://www.inbeat.co/:splat 301!
-
-
-
-
-


### PR DESCRIPTION
This PR is a first step towards migrating the blog to Ghost. It proxies all requests from `/blog` to the Ghost instance.
Since Ghost uses relative path, I also needed to proxy requests to `/public`, `/assets` and `/content`. These URLs cannot be used anymore by the website, until we can fix this issue with Ghost (if it's fixable!).

This PR doesn't really affect the live site, as it is for demonstration purposes. Another PR will take care of using the new `/blog` URL and manipulate the sitemap to point to Ghost.