### PR TITLE
FIX: Remove selectedUserType

### DIFF
--- a/themes/inbeat/layouts/singles/engagement-rate.html
+++ b/themes/inbeat/layouts/singles/engagement-rate.html
@@ -90,12 +90,9 @@
                         {{- end -}}
                     </div>
                 </div>
-                <a href="https://teaminbeat.typeform.com/to/sLHT8z3M" class="btn btn-lg btn-light calc-cta-btn" target="_blank" v-if="selectedUserType === 'Influencer'">
-                   Sign-up as a <b>Creator</b>
-                </a>
                 <a href="https://app.inbeat.co/get-started" class="btn btn-lg btn-light" target="_blank" v-else>
-                    Find Similar <b>Creators</b>
-                 </a>
+                  Find Similar <b>Creators</b>
+                </a>
             </div>
             <div class="col-xs-12 col-md-8 posts-info">
                 <div class="row">


### PR DESCRIPTION
### Remove selectedUserType

It's missing and we don't use it. It causes the profile render to break

![image](https://github.com/user-attachments/assets/5dd7148e-661c-41cc-843b-8fa0751e931e)

Did not actually test as it's hard to render profiles on localhost, but removing this div should help

Let me know