### PR TITLE
Remove duplicate hide popup that prevented set cookies

### DIFF
--- a/themes/inbeat/layouts/partials/site/mixin/unlockCalculator.html
+++ b/themes/inbeat/layouts/partials/site/mixin/unlockCalculator.html
@@ -19,17 +19,12 @@
         this.toggleScroll(true);
         return true;
       },
-      async hideUnlockPopup() {
-        await setCookie(this.cookieName, "true", 90);
-        this.popupClass = "";
-        this.toggleScroll(false);
-      },
       toggleScroll(disable) {
         document.body.style.overflow = disable ? "hidden" : "";
       },
       outsideClick(event) {
         if (event.target.classList.contains('popupOverlay') && this.profileType === "creator") {
-          this.hideUnlockPopup();
+          this.hidePopup();
         }
       },
       setProfileType(type) {
@@ -53,7 +48,8 @@
           this.beehiivLoading = false;
         }
       },
-      hidePopup() {
+      async hidePopup() {
+        await setCookie(this.cookieName, "true", 90);
         this.popupClass = "";
         this.toggleScroll(false);
       },

--- a/themes/inbeat/layouts/partials/site/showcase-popup.html
+++ b/themes/inbeat/layouts/partials/site/showcase-popup.html
@@ -1,13 +1,13 @@
 <div class="showcase-popup">
   <div class="wrapper">
-    <div @click="hideUnlockPopup" class="close">{{ partial "icons/close.html" . }}</div>
+    <div @click="hidePopup" class="close">{{ partial "icons/close.html" . }}</div>
     <img src="/images/showcase.png" alt="">
     <div class="aside">
       <div class="text">
         <h4 class="title">Collaborate with top brands & get paid.</h4>
         <p class="subtext">Showcase is a platform that connects brands & creators to create UGC.</p>
       </div>
-      <a href="https://www.showca.se/" @click="hideUnlockPopup" class="cta" title="Get started"
+      <a href="https://www.showca.se/" @click="hidePopup" class="cta" title="Get started"
         target="_blank">
         Learn more
       </a>


### PR DESCRIPTION
The hideUnlockPopup function was the only one that was setting the cookies, and the showcase popup was the only one to use that function.