### PR TITLE
feat(redirects): redirect top paid media agencies in New York to inbeat.agency

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -85,6 +85,7 @@
 /articles/top-performance-creative-agencies/ https://inbeat.agency/blog/top-performance-creative-agencies 301
 /articles/top-search-engine-marketing-agencies/ https://inbeat.agency/blog/top-search-engine-marketing-agencies 301
 /articles/top-paid-media-agencies-in-the-us/ https://inbeat.agency/blog/top-paid-media-agencies-in-nyc 301
+/articles/top-paid-media-agencies-new-york/ https://inbeat.agency/blog/top-paid-media-agencies-in-nyc 301
 /articles/top-social-media-agencies-in-the-uk/ https://inbeat.agency/blog/top-social-media-agencies-in-the-uk 301
 /articles/top-social-media-marketing-agencies-dubai/ https://inbeat.agency/blog/best-social-media-agencies-dubai 301
 /articles/top-digital-marketing-agencies-toronto/ https://inbeat.agency/blog/top-digital-marketing-agencies-toronto 301


### PR DESCRIPTION
## Summary
- Adds a 301 redirect from `/articles/top-paid-media-agencies-new-york/` to `https://inbeat.agency/blog/top-paid-media-agencies-in-nyc`.
- The article was disabled on `inbeat.co`, so we point users (and SEO equity) to the equivalent NYC post on `inbeat.agency`.

## Context
Sits in the existing "IS → IA migration (Article Disabled)" block in `static/_redirects`, right next to `top-paid-media-agencies-in-the-us/` which already redirects to the same destination. Grouping related slugs together keeps the file scannable.

## Verification
After Netlify deploys:
```
curl -I https://www.inbeat.co/articles/top-paid-media-agencies-new-york/
```
Expected: `301` → `https://inbeat.agency/blog/top-paid-media-agencies-in-nyc`.